### PR TITLE
Add SLSA Go release workflow

### DIFF
--- a/.github/workflows/go-ossf-slsa3-publish.yml
+++ b/.github/workflows/go-ossf-slsa3-publish.yml
@@ -1,0 +1,37 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+# This workflow lets you compile your Go project using a SLSA3 compliant builder.
+# This workflow will generate a so-called "provenance" file describing the steps
+# that were performed to generate the final binary.
+# The project is an initiative of the OpenSSF (openssf.org) and is developed at
+# https://github.com/slsa-framework/slsa-github-generator.
+# The provenance file can be verified using https://github.com/slsa-framework/slsa-verifier.
+# For more information about SLSA and how it improves the supply-chain, visit slsa.dev.
+
+name: SLSA Go releaser
+on:
+  workflow_dispatch:
+  release:
+    types: [created]
+
+permissions: read-all
+
+jobs:
+  # ========================================================================================================================================
+  #     Prerequesite: Create a .slsa-goreleaser.yml in the root directory of your project.
+  #       See format in https://github.com/slsa-framework/slsa-github-generator/blob/main/internal/builders/go/README.md#configuration-file
+  #=========================================================================================================================================
+  build:
+    permissions:
+      id-token: write # To sign.
+      contents: write # To upload release assets.
+      actions: read   # To read workflow path.
+    uses: slsa-framework/slsa-github-generator/.github/workflows/builder_go_slsa3.yml@v1.4.0
+    with:
+      go-version: 1.17
+      # =============================================================================================================
+      #     Optional: For more options, see https://github.com/slsa-framework/slsa-github-generator#golang-projects
+      # =============================================================================================================


### PR DESCRIPTION
### Motivation
- Provide a SLSA3-compliant GitHub Actions workflow to produce provenance for Go releases and enable reproducible, signed builds.

### Description
- Add `.github/workflows/go-ossf-slsa3-publish.yml` which triggers on `workflow_dispatch` and `release` (created), sets `permissions: read-all`, configures a `build` job with `id-token: write`, `contents: write`, and `actions: read`, and delegates the build to `slsa-framework/slsa-github-generator` with `go-version: 1.17`.

### Testing
- Ran `git diff --check --cached` and validated the workflow YAML with `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/go-ossf-slsa3-publish.yml')"`, both checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcee60d950832c9a33b8898a3ca6b7)