### PR TITLE
Update SLSA Go reusable workflow pin to v1.10.0

### DIFF
--- a/.github/workflows/go-ossf-slsa3-publish.yml
+++ b/.github/workflows/go-ossf-slsa3-publish.yml
@@ -29,7 +29,7 @@ jobs:
       id-token: write # To sign.
       contents: write # To upload release assets.
       actions: read   # To read workflow path.
-    uses: slsa-framework/slsa-github-generator/.github/workflows/builder_go_slsa3.yml@v1.4.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/builder_go_slsa3.yml@v1.10.0
     with:
       go-version: 1.17
       # =============================================================================================================


### PR DESCRIPTION
### Motivation
- Update the pinned `slsa-framework/slsa-github-generator` reusable workflow to `v1.10.0` to avoid the known TUF remote mirror failure present in generator versions up through `v1.9.0`, which would prevent provenance signing.

### Description
- Replace the `uses` line in ` .github/workflows/go-ossf-slsa3-publish.yml` from `builder_go_slsa3.yml@v1.4.0` to `builder_go_slsa3.yml@v1.10.0` to ensure a non-affected SLSA generator is used.

### Testing
- Ran `git diff --check` and validated the workflow YAML with `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/go-ossf-slsa3-publish.yml')"`, both checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd0224ed40832c8bda957af3dca5af)