### PR TITLE
Pin SLSA Go workflow to artifact-v4-compatible v2.1.0

### DIFF
--- a/.github/workflows/go-ossf-slsa3-publish.yml
+++ b/.github/workflows/go-ossf-slsa3-publish.yml
@@ -29,7 +29,7 @@ jobs:
       id-token: write # To sign.
       contents: write # To upload release assets.
       actions: read   # To read workflow path.
-    uses: slsa-framework/slsa-github-generator/.github/workflows/builder_go_slsa3.yml@v1.10.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/builder_go_slsa3.yml@v2.1.0
     with:
       go-version: 1.17
       # =============================================================================================================


### PR DESCRIPTION
### Motivation
- The reusable SLSA generator pinned at `v1.10.0` still referenced `actions/upload-artifact@v3` internally which will fail for GitHub-hosted releases after the artifact-v3 cutoff.
- Pinning to a `v2.x` generator that uses artifact v4 is required to restore provenance signing and avoid the high-priority release breakage.

### Description
- Updated the `uses` line in ` .github/workflows/go-ossf-slsa3-publish.yml` from `builder_go_slsa3.yml@v1.10.0` to `builder_go_slsa3.yml@v2.1.0` so the reusable workflow comes from the v2 line.
- This change ensures the generator's internal `actions/upload-artifact` steps are on an artifact-v4-compatible line and prevents failures before provenance signing.

### Testing
- Ran `git diff --check` to ensure no whitespace or diff errors and it succeeded. 
- Loaded the workflow YAML with `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/go-ossf-slsa3-publish.yml')"` to validate parsing and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd038d0a84832c91255e7669361891)