### PR TITLE
Add Roblox develop mode documentation and join link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
 # kenzy
+
+## Modes
+
+- [Roblox develop mode](modes/roblox-develop.md): guidance for Roblox Studio, Luau, and asset iteration during development.
+- [Roblox experience join link](https://www.roblox.com/join/2wv0w): quick link for joining the shared Roblox experience.

--- a/modes/roblox-develop.md
+++ b/modes/roblox-develop.md
@@ -1,0 +1,32 @@
+# Roblox Develop Mode
+
+Roblox develop mode is a project profile for building and iterating on Roblox experiences.
+Use it when work targets Roblox Studio, Luau scripts, or asset workflows that need quick local iteration before release.
+
+## Goals
+
+- Keep Roblox-specific changes isolated from release configuration.
+- Prefer fast feedback loops for Luau scripts, place files, assets, and documentation.
+- Document assumptions about Studio-only APIs, server/client boundaries, and asset IDs before shipping.
+
+## Roblox Join Link
+
+Use this Roblox join link when you need to open or test the shared experience:
+
+- <https://www.roblox.com/join/2wv0w>
+
+## Workflow
+
+1. Create feature work in the development branch or workspace.
+2. Sync or edit Roblox assets and Luau code locally.
+3. Test gameplay changes in Roblox Studio with both client and server simulation enabled.
+4. Record any required asset IDs, permissions, or manual Studio steps in the change notes.
+5. Promote the change only after Studio testing passes.
+
+## Checklist
+
+- [ ] Luau scripts are formatted consistently.
+- [ ] Client and server code paths are tested in Roblox Studio.
+- [ ] New assets include source notes and ownership details.
+- [ ] Security-sensitive APIs, remotes, and permissions are reviewed.
+- [ ] Release notes mention Roblox-specific setup or migration steps.


### PR DESCRIPTION
### Motivation
- Provide a dedicated project profile for developing and iterating Roblox experiences, covering Studio, Luau, and asset workflows.
- Surface a quick join link for the shared Roblox experience and document development assumptions and steps to reduce friction during local testing.

### Description
- Added `modes/roblox-develop.md` with goals, workflow, checklist, and the shared Roblox join link.
- Updated `README.md` to include a `Modes` section that links to `modes/roblox-develop.md` and exposes the join link.

### Testing
- No automated tests were run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd858536a4832c99836bb2e99b506e)